### PR TITLE
adding minimal key to gdextension

### DIFF
--- a/project/addons/embed_external_editor/embed_external_editor.gdextension
+++ b/project/addons/embed_external_editor/embed_external_editor.gdextension
@@ -1,6 +1,7 @@
 [configuration]
 
 entry_symbol = "gdextension_init"
+compatibility_minimum = "4.1"
 
 [libraries]
 

--- a/project/addons/embed_external_editor/embed_external_editor.gdextension
+++ b/project/addons/embed_external_editor/embed_external_editor.gdextension
@@ -1,7 +1,7 @@
 [configuration]
 
 entry_symbol = "gdextension_init"
-compatibility_minimum = "4.1"
+compatibility_minimum = "4.0"
 
 [libraries]
 


### PR DESCRIPTION
To avoid this error:
ERROR: core/extension/gdextension_library_loader.cpp:299 - GDExtension configuration file must contain a "configuration/compatibility_minimum" key: 'res://addons/embed_external_editor/embed_external_editor.gdextension'.