### PR TITLE
CI: Update GitHub Actions workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,7 +3,6 @@ on:
   push:
     branches:
       - master
-      - 17-update-ci-actions
   pull_request:
     types: [opened, reopened, synchronize, ready_for_review]
   workflow_dispatch:


### PR DESCRIPTION
Fixes #17 

### Changes
- Use modern GitHub Actions
  - actions/checkout → v4
  - actions/setup-python → v5
  - actions/setup-java → v4

- Remove deprecated syntax
  - Replaced ::set-output with GITHUB_OUTPUT

- Safe artifact naming
  - Version names sanitized (slashes replaced with dashes)
  - Artifact names now include: build identifier + safe version + commit SHA

- Keep optional caching commented out
  - Cache step left in place but disabled (SCons rebuild issue noted)

### Why
- Keeps workflow compatible with the latest GitHub Actions
- Prevents build failures from unsafe characters in artifact names
- Ensures reproducible and uniquely identifiable artifacts

### Next Steps
- [ ] Verify artifacts in PR run (names and contents)
- [ ] Confirm that windows-debug and windows-release jobs pass